### PR TITLE
django==3.0.9 should be required explicitly

### DIFF
--- a/getlino/setup_info.py
+++ b/getlino/setup_info.py
@@ -1,7 +1,7 @@
 SETUP_INFO = dict(
     name='getlino',
     version='20.7.5',
-    install_requires=['click', 'virtualenv', 'jinja2', 'distro'],
+    install_requires=['django==3.0.9', 'click', 'virtualenv', 'jinja2', 'distro'],
     # tests_require=['docker', 'atelier'],
     # test_suite='tests',
     description="Lino installer",


### PR DESCRIPTION
django 3.1 and newer will break the installation of lino because lino depends on compatibility import of django.core.exceptions.FieldDoesNotExist in django.db.models.fields which is removed from django 3.1 so i suggest to require django==3.0.9 here, otherwise later required packages will bring in latest django and installation via getlino will fail.